### PR TITLE
Fixes the sponsors list

### DIFF
--- a/frontend/styles/blocks/sponsors.scss
+++ b/frontend/styles/blocks/sponsors.scss
@@ -4,13 +4,13 @@
 .sponsors {
   &__card {
     position: relative;
-    flex-basis: calc(50% - 20px);
+    max-width: calc(50% - 20px);
     display: flex;
     flex-direction: column;
     align-items: center;
 
     @include mq.mq($until: desktop) {
-      flex-basis: calc(100% - 20px);
+      max-width: calc(100% - 20px);
     }
   }
 

--- a/frontend/styles/blocks/sponsors.scss
+++ b/frontend/styles/blocks/sponsors.scss
@@ -119,6 +119,7 @@
         flex-basis: auto;
         justify-content: center;
         padding: 30px 25px;
+        height: 90px;
       }
 
       img {

--- a/src/_components/home/sponsors.liquid
+++ b/src/_components/home/sponsors.liquid
@@ -18,13 +18,14 @@
 
           {% for level in levels %}
             {% assign sponsors = collections.sponsors.resources | where: "data.level", level %}
-            {% for sponsor in sponsors %}
+            {% if sponsors.size > 0 %}
               <div class="sponsors__list sponsors__list--{{ level }}">
-                {{ sponsor.content }}
+                {% for sponsor in sponsors %}
+                    {{ sponsor.content }}
+                {% endfor %}
               </div>
-            {% endfor %}
+            {% endif %}
           {% endfor %}
-
           <h2 class="sponsors__text-right">Want to see your logo here? Consider <a href="/sponsoring">sponsoring us.</a></h2>
         </div>
       </div>


### PR DESCRIPTION
Make the sponsors of the same level go in the same container

**TODO**

- [x] Make the Silver/Bronze level logos (or rather their containers) the same height

**Before**

<img width="1904" alt="Before" src="https://user-images.githubusercontent.com/43314/156796061-2a5dd62e-9e64-4b6e-b991-f6763f799e26.png">

**After**

<img width="1904" alt="After" src="https://user-images.githubusercontent.com/43314/156796067-84705876-b668-46cb-a424-35956d3ff035.png">

